### PR TITLE
fixed the bug of losing player data when issuing coins

### DIFF
--- a/src/main/java/com/Lino/battlePass/managers/PlayerDataManager.java
+++ b/src/main/java/com/Lino/battlePass/managers/PlayerDataManager.java
@@ -90,4 +90,22 @@ public class PlayerDataManager {
         playerCache.keySet().removeIf(uuid -> Bukkit.getPlayer(uuid) == null);
         dirtyPlayers.removeIf(uuid -> Bukkit.getPlayer(uuid) == null);
     }
+
+    public CompletableFuture<Boolean> addBattleCoins(UUID uuid, int amount) {
+        PlayerData cacheData = playerCache.get(uuid);
+        if (cacheData != null) {
+            cacheData.battleCoins += amount;
+            markForSave(uuid);
+            return CompletableFuture.completedFuture(true);
+        }
+
+        return databaseManager.loadPlayerData(uuid).thenApply(data -> {
+            if (data == null) return false;
+
+            data.battleCoins += amount;
+            playerCache.put(uuid, data);
+            markForSave(uuid);
+            return true;
+        });
+    }
 }

--- a/src/main/java/com/Lino/battlePass/tasks/CoinsDistributionTask.java
+++ b/src/main/java/com/Lino/battlePass/tasks/CoinsDistributionTask.java
@@ -52,8 +52,6 @@ public class CoinsDistributionTask extends BukkitRunnable {
                     PlayerData topPlayer = topPlayers.get(i);
                     int coins = coinAmounts.get(i);
 
-                    topPlayer.battleCoins += coins;
-
                     String playerName = Bukkit.getOfflinePlayer(topPlayer.uuid).getName();
                     String rank = String.valueOf(i + 1);
 
@@ -62,21 +60,15 @@ public class CoinsDistributionTask extends BukkitRunnable {
                             "%player%", playerName,
                             "%amount%", String.valueOf(coins)));
 
-                    Player player = Bukkit.getPlayer(topPlayer.uuid);
-                    if (player != null) {
-                        PlayerData onlineData = plugin.getPlayerDataManager().getPlayerData(topPlayer.uuid);
-                        if (onlineData != null) {
-                            onlineData.battleCoins = topPlayer.battleCoins;
-                            plugin.getPlayerDataManager().markForSave(topPlayer.uuid);
+                    plugin.getPlayerDataManager().addBattleCoins(topPlayer.uuid, coins).thenAccept(success -> {
+                        Player player = Bukkit.getPlayer(topPlayer.uuid);
+                        if (player != null) {
+                            player.sendMessage(plugin.getMessageManager().getPrefix() +
+                                    plugin.getMessageManager().getMessage("messages.coins.received",
+                                            "%amount%", String.valueOf(coins)));
+                            player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
                         }
-
-                        player.sendMessage(plugin.getMessageManager().getPrefix() +
-                                plugin.getMessageManager().getMessage("messages.coins.received",
-                                        "%amount%", String.valueOf(coins)));
-                        player.playSound(player.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1.0f, 1.0f);
-                    } else {
-                        plugin.getDatabaseManager().savePlayerData(topPlayer.uuid, topPlayer);
-                    }
+                    });
                 }
             });
         });


### PR DESCRIPTION
Found and fixed the actual source of the bug when player data was lost. Previously, when issuing rewards, only truncated information about the offline player was written to the database.