### PR TITLE
Fixed data saving in saveSeasonData. Added support for season reset at the beginning of the month.

### DIFF
--- a/src/main/java/com/Lino/battlePass/managers/ConfigManager.java
+++ b/src/main/java/com/Lino/battlePass/managers/ConfigManager.java
@@ -6,6 +6,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 
 import java.io.File;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -163,8 +164,26 @@ public class ConfigManager {
         return dailyMissionsCount;
     }
 
-    public int getSeasonDuration() {
-        return seasonDuration;
+    public LocalDateTime calculateSeasonEndDate() {
+        String resetType = getConfig().getString("season.reset-type", "DURATION");
+        int duration = seasonDuration;
+
+        LocalDateTime now = LocalDateTime.now();
+
+        if ("MONTH_START".equalsIgnoreCase(resetType)) {
+            return now.plusMonths(1)
+                    .withDayOfMonth(1)
+                    .withHour(0)
+                    .withMinute(0)
+                    .withSecond(0)
+                    .withNano(0);
+        } else {
+            return now.plusDays(duration)
+                    .withHour(0)
+                    .withMinute(0)
+                    .withSecond(0)
+                    .withNano(0);
+        }
     }
 
     public int getDailyRewardXP() {

--- a/src/main/java/com/Lino/battlePass/managers/MissionManager.java
+++ b/src/main/java/com/Lino/battlePass/managers/MissionManager.java
@@ -53,7 +53,7 @@ public class MissionManager {
                     return;
                 }
             } else {
-                resetHandler.setSeasonEndDate(LocalDateTime.now().plusDays(configManager.getSeasonDuration()));
+                resetHandler.setSeasonEndDate(configManager.calculateSeasonEndDate());
                 currentMissionDate = LocalDateTime.now().toLocalDate().toString();
                 resetHandler.calculateNextReset();
                 saveSeasonData();
@@ -195,7 +195,6 @@ public class MissionManager {
     private void saveSeasonData() {
         databaseManager.saveSeasonData(
                 resetHandler.getSeasonEndDate(),
-                configManager.getSeasonDuration(),
                 resetHandler.getNextMissionReset(),
                 currentMissionDate
         );

--- a/src/main/java/com/Lino/battlePass/managers/MissionResetHandler.java
+++ b/src/main/java/com/Lino/battlePass/managers/MissionResetHandler.java
@@ -60,7 +60,7 @@ public class MissionResetHandler {
         plugin.getDatabaseManager().resetSeason();
         plugin.getPlayerDataManager().clearCache();
 
-        seasonEndDate = LocalDateTime.now().plusDays(plugin.getConfigManager().getSeasonDuration());
+        seasonEndDate = plugin.getConfigManager().calculateSeasonEndDate();
     }
 
     public void forceResetSeason() {
@@ -77,7 +77,7 @@ public class MissionResetHandler {
             plugin.getDatabaseManager().resetSeason().thenRun(() -> {
                 Bukkit.getScheduler().runTask(plugin, () -> {
                     plugin.getPlayerDataManager().clearCache();
-                    seasonEndDate = LocalDateTime.now().plusDays(plugin.getConfigManager().getSeasonDuration());
+                    seasonEndDate = plugin.getConfigManager().calculateSeasonEndDate();
                     calculateNextReset();
 
                     for (Player player : Bukkit.getOnlinePlayers()) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,7 +1,9 @@
 # Battle Pass Configuration
 
-# Season duration in days
 season:
+  # Reset type: MONTH_START (reset at beginning of month) or DURATION (reset after X days)
+  reset-type: "DURATION"
+  # Season duration in days (only used when reset-type is DURATION)
   duration: 30
   # Whether to reset battle coins when season ends
   reset-coins-on-season-end: true


### PR DESCRIPTION
1) Removed unused field duration from season_data
2) Fixed data saving in saveSeasonData - this method no longer overwrites the next_coins_distribution field with null
3) Added support for season reset at the beginning of the month in the config (By default, DURATION is still used, switching to month start is an optional feature).
Config changes to switch to season reset at the beginning of the month:
```
season:
  # Reset type: MONTH_START (reset at beginning of month) or DURATION (reset after X days)
  reset-type: "MONTH_START"
  # Season duration in days (only used when reset-type is DURATION)
  duration: 30
```