### PR TITLE
feat: Leaderboard configurable - ordenamiento, tamaño, posición del jugador

### DIFF
--- a/src/main/java/com/Lino/battlePass/gui/LeaderboardGui.java
+++ b/src/main/java/com/Lino/battlePass/gui/LeaderboardGui.java
@@ -29,6 +29,7 @@ public class LeaderboardGui extends BaseGui {
 
         setupTitleItem(gui);
         setupLeaderboard(gui);
+        setupPlayerRank(gui);
 
         if (plugin.getConfigManager().isShopEnabled()) {
             setupCoinsInfo(gui);
@@ -61,15 +62,16 @@ public class LeaderboardGui extends BaseGui {
     }
 
     private void setupLeaderboard(Inventory gui) {
+        int leaderboardSize = plugin.getConfigManager().getLeaderboardSize();
+        int xpPerLevel = plugin.getConfigManager().getXpPerLevel();
+
         plugin.getDatabaseManager().getTop10Players().thenAccept(topPlayers -> {
             Bukkit.getScheduler().runTask(plugin, () -> {
-                int[] slots = {19, 20, 21, 22, 23, 24, 25, 28, 29, 30};
-
-                for (int i = 0; i < topPlayers.size() && i < 10; i++) {
+                // Row 2 (slots 9-17), Row 3 (slots 18-26), Row 4 (slots 27+)
+                for (int i = 0; i < topPlayers.size() && i < leaderboardSize; i++) {
                     PlayerData topPlayer = topPlayers.get(i);
                     OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(topPlayer.uuid);
 
-                    // FIX: Controllo se il nome è null per evitare il crash
                     String playerName = offlinePlayer.getName();
                     if (playerName == null) {
                         playerName = "Unknown";
@@ -92,12 +94,16 @@ public class LeaderboardGui extends BaseGui {
                             plugin.getMessageManager().getMessage("items.leaderboard-status.you") :
                             plugin.getMessageManager().getMessage("items.leaderboard-status.other");
 
+                    String progressBar = createProgressBar(topPlayer.xp, xpPerLevel);
+
                     List<String> lore = new ArrayList<>();
                     for (String line : plugin.getMessageManager().getMessagesConfig().getStringList("items.leaderboard-player.lore")) {
                         String processedLine = line
                                 .replace("%level%", String.valueOf(topPlayer.level))
                                 .replace("%total_levels%", String.valueOf(topPlayer.totalLevels))
                                 .replace("%xp%", String.valueOf(topPlayer.xp))
+                                .replace("%xp_needed%", String.valueOf(xpPerLevel))
+                                .replace("%progress_bar%", progressBar)
                                 .replace("%coins%", String.valueOf(topPlayer.battleCoins))
                                 .replace("%status%", status);
                         lore.add(GradientColorParser.parse(processedLine));
@@ -105,8 +111,52 @@ public class LeaderboardGui extends BaseGui {
 
                     skullMeta.setLore(lore);
                     skull.setItemMeta(skullMeta);
-                    gui.setItem(slots[i], skull);
+                    // Slots: 9-17 (row 2), 18-26 (row 3), 27-35 (row 4)
+                    gui.setItem(9 + i, skull);
                 }
+
+                if (player.getOpenInventory().getTitle().equals(title)) {
+                    player.updateInventory();
+                }
+            });
+        });
+    }
+
+    private void setupPlayerRank(Inventory gui) {
+        int xpPerLevel = plugin.getConfigManager().getXpPerLevel();
+        int minLevel = plugin.getConfigManager().getLeaderboardMinLevel();
+
+        plugin.getDatabaseManager().getPlayerRankInfo(player.getUniqueId()).thenAccept(rankInfo -> {
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                int rank = rankInfo[0];
+                int total = rankInfo[1];
+
+                PlayerData data = plugin.getPlayerDataManager().getPlayerData(player.getUniqueId());
+                if (data == null) return;
+
+                ItemStack item = new ItemStack(Material.RECOVERY_COMPASS);
+                ItemMeta meta = item.getItemMeta();
+                meta.setDisplayName(plugin.getMessageManager().getMessage("items.player-rank.name"));
+
+                String progressBar = createProgressBar(data.xp, xpPerLevel);
+                String lorePath = rank > 0 ? "items.player-rank.lore-ranked" : "items.player-rank.lore-unranked";
+
+                List<String> lore = new ArrayList<>();
+                for (String line : plugin.getMessageManager().getMessagesConfig().getStringList(lorePath)) {
+                    String processedLine = line
+                            .replace("%rank%", rank > 0 ? String.valueOf(rank) : "-")
+                            .replace("%total%", String.valueOf(total))
+                            .replace("%level%", String.valueOf(data.level))
+                            .replace("%xp%", String.valueOf(data.xp))
+                            .replace("%xp_needed%", String.valueOf(xpPerLevel))
+                            .replace("%progress_bar%", progressBar)
+                            .replace("%min_level%", String.valueOf(minLevel));
+                    lore.add(GradientColorParser.parse(processedLine));
+                }
+
+                meta.setLore(lore);
+                item.setItemMeta(meta);
+                gui.setItem(31, item);
 
                 if (player.getOpenInventory().getTitle().equals(title)) {
                     player.updateInventory();
@@ -131,6 +181,20 @@ public class LeaderboardGui extends BaseGui {
 
         meta.setLore(lore);
         coinsInfo.setItemMeta(meta);
-        gui.setItem(40, coinsInfo);
+        gui.setItem(34, coinsInfo);
+    }
+
+    private String createProgressBar(int current, int max) {
+        int totalBars = 10;
+        int filled;
+        if (max <= 0) {
+            filled = 0;
+        } else {
+            filled = Math.min(totalBars, (int) Math.round((double) current / max * totalBars));
+        }
+        StringBuilder bar = new StringBuilder();
+        for (int i = 0; i < filled; i++) bar.append("&a█");
+        for (int i = filled; i < totalBars; i++) bar.append("&8░");
+        return bar.toString();
     }
 }

--- a/src/main/java/com/Lino/battlePass/managers/ConfigManager.java
+++ b/src/main/java/com/Lino/battlePass/managers/ConfigManager.java
@@ -30,6 +30,12 @@ public class ConfigManager {
     private int missionResetHours = 24;
     private boolean customItemSoundsEnabled = true;
 
+    private String leaderboardSortBy = "level";
+    private String leaderboardTiebreaker = "xp";
+    private int leaderboardMinLevel = 2;
+    private int leaderboardSize = 20;
+    private boolean resetTotalLevelsOnSeasonEnd = true;
+
     private Material guiFreeLockedMaterial = Material.GRAY_STAINED_GLASS;
     private Material guiPremiumLockedMaterial = Material.GRAY_STAINED_GLASS;
     private Material guiPremiumNoPassMaterial = Material.IRON_BARS;
@@ -65,6 +71,12 @@ public class ConfigManager {
         coinsDistributionHours = config.getInt("battle-coins.distribution-hours", 24);
         missionResetHours = config.getInt("missions.reset-hours", 24);
         customItemSoundsEnabled = config.getBoolean("custom-items.sounds-enabled", true);
+
+        leaderboardSortBy = config.getString("leaderboard.sort-by", "level").toLowerCase();
+        leaderboardTiebreaker = config.getString("leaderboard.tiebreaker", "xp").toLowerCase();
+        leaderboardMinLevel = config.getInt("leaderboard.min-level", 2);
+        leaderboardSize = Math.min(config.getInt("leaderboard.size", 20), 27);
+        resetTotalLevelsOnSeasonEnd = config.getBoolean("leaderboard.reset-total-levels-on-season-end", true);
 
         databaseType = config.getString("database.type", "SQLITE");
         dbHost = config.getString("database.host", "localhost");
@@ -267,5 +279,25 @@ public class ConfigManager {
 
     public int getDbPoolSize() {
         return dbPoolSize;
+    }
+
+    public String getLeaderboardSortBy() {
+        return leaderboardSortBy;
+    }
+
+    public String getLeaderboardTiebreaker() {
+        return leaderboardTiebreaker;
+    }
+
+    public int getLeaderboardMinLevel() {
+        return leaderboardMinLevel;
+    }
+
+    public int getLeaderboardSize() {
+        return leaderboardSize;
+    }
+
+    public boolean isResetTotalLevelsOnSeasonEnd() {
+        return resetTotalLevelsOnSeasonEnd;
     }
 }

--- a/src/main/java/com/Lino/battlePass/managers/DatabaseManager.java
+++ b/src/main/java/com/Lino/battlePass/managers/DatabaseManager.java
@@ -371,15 +371,34 @@ public class DatabaseManager {
         }, databaseExecutor);
     }
 
+    private String mapSortColumn(String configValue) {
+        switch (configValue) {
+            case "level": return "level";
+            case "total_levels": return "total_levels";
+            case "xp": return "xp";
+            case "battle_coins": return "battle_coins";
+            default: return "level";
+        }
+    }
+
     public CompletableFuture<List<PlayerData>> getTop10Players() {
         return CompletableFuture.supplyAsync(() -> {
             List<PlayerData> allPlayers = new ArrayList<>();
             Connection conn = null;
             boolean shouldClose = isMySQL;
 
+            String sortBy = mapSortColumn(plugin.getConfigManager().getLeaderboardSortBy());
+            String tiebreaker = mapSortColumn(plugin.getConfigManager().getLeaderboardTiebreaker());
+            int minLevel = plugin.getConfigManager().getLeaderboardMinLevel();
+            int limit = plugin.getConfigManager().getLeaderboardSize();
+
+            String query = "SELECT * FROM " + prefix + "players WHERE exclude_from_top = 0 AND level >= ? ORDER BY " + sortBy + " DESC, " + tiebreaker + " DESC LIMIT ?";
+
             try {
                 conn = getConnection();
-                try (PreparedStatement ps = conn.prepareStatement("SELECT * FROM " + prefix + "players WHERE exclude_from_top = 0 ORDER BY total_levels DESC, level DESC, xp DESC LIMIT 10")) {
+                try (PreparedStatement ps = conn.prepareStatement(query)) {
+                    ps.setInt(1, minLevel);
+                    ps.setInt(2, limit);
                     try (ResultSet rs = ps.executeQuery()) {
                         while (rs.next()) {
                             PlayerData data = new PlayerData(UUID.fromString(rs.getString("uuid")));
@@ -400,6 +419,73 @@ public class DatabaseManager {
                 }
             }
             return allPlayers;
+        }, databaseExecutor);
+    }
+
+    /**
+     * Returns [rank, totalEligiblePlayers]. rank=-1 if player is not eligible.
+     */
+    public CompletableFuture<int[]> getPlayerRankInfo(UUID uuid) {
+        return CompletableFuture.supplyAsync(() -> {
+            int[] result = new int[]{-1, 0};
+            Connection conn = null;
+            boolean shouldClose = isMySQL;
+
+            String sortBy = mapSortColumn(plugin.getConfigManager().getLeaderboardSortBy());
+            String tiebreaker = mapSortColumn(plugin.getConfigManager().getLeaderboardTiebreaker());
+            int minLevel = plugin.getConfigManager().getLeaderboardMinLevel();
+
+            try {
+                conn = getConnection();
+
+                int playerLevel = 0, playerSortVal = 0, playerTieVal = 0;
+                boolean excluded = false;
+                boolean found = false;
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "SELECT level, xp, total_levels, battle_coins, exclude_from_top FROM " + prefix + "players WHERE uuid = ?")) {
+                    ps.setString(1, uuid.toString());
+                    try (ResultSet rs = ps.executeQuery()) {
+                        if (rs.next()) {
+                            found = true;
+                            playerLevel = rs.getInt("level");
+                            playerSortVal = rs.getInt(sortBy);
+                            playerTieVal = rs.getInt(tiebreaker);
+                            excluded = rs.getInt("exclude_from_top") == 1;
+                        }
+                    }
+                }
+
+                try (PreparedStatement ps = conn.prepareStatement(
+                        "SELECT COUNT(*) FROM " + prefix + "players WHERE exclude_from_top = 0 AND level >= ?")) {
+                    ps.setInt(1, minLevel);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        if (rs.next()) result[1] = rs.getInt(1);
+                    }
+                }
+
+                if (!found || excluded || playerLevel < minLevel) {
+                    return result;
+                }
+
+                String rankQuery = "SELECT COUNT(*) FROM " + prefix + "players WHERE exclude_from_top = 0 AND level >= ? AND (" +
+                        sortBy + " > ? OR (" + sortBy + " = ? AND " + tiebreaker + " > ?))";
+                try (PreparedStatement ps = conn.prepareStatement(rankQuery)) {
+                    ps.setInt(1, minLevel);
+                    ps.setInt(2, playerSortVal);
+                    ps.setInt(3, playerSortVal);
+                    ps.setInt(4, playerTieVal);
+                    try (ResultSet rs = ps.executeQuery()) {
+                        if (rs.next()) result[0] = rs.getInt(1) + 1;
+                    }
+                }
+            } catch (SQLException e) {
+                e.printStackTrace();
+            } finally {
+                if (shouldClose && conn != null) {
+                    try { conn.close(); } catch (SQLException e) {}
+                }
+            }
+            return result;
         }, databaseExecutor);
     }
 
@@ -670,12 +756,17 @@ public class DatabaseManager {
                 conn = getConnection();
                 try (Statement stmt = conn.createStatement()) {
                     boolean resetCoins = plugin.getConfigManager().isResetCoinsOnSeasonEnd();
+                    boolean resetTotalLevels = plugin.getConfigManager().isResetTotalLevelsOnSeasonEnd();
 
+                    StringBuilder sql = new StringBuilder("UPDATE " + prefix + "players SET xp = 0, level = 1, claimed_free = '', claimed_premium = '', has_premium = 0, last_daily_reward = 0");
                     if (resetCoins) {
-                        stmt.executeUpdate("UPDATE " + prefix + "players SET xp = 0, level = 1, claimed_free = '', claimed_premium = '', has_premium = 0, last_daily_reward = 0, battle_coins = 0");
-                    } else {
-                        stmt.executeUpdate("UPDATE " + prefix + "players SET xp = 0, level = 1, claimed_free = '', claimed_premium = '', has_premium = 0, last_daily_reward = 0");
+                        sql.append(", battle_coins = 0");
                     }
+                    if (resetTotalLevels) {
+                        sql.append(", total_levels = 0");
+                    }
+                    stmt.executeUpdate(sql.toString());
+
                     stmt.executeUpdate("DELETE FROM " + prefix + "missions");
                     stmt.executeUpdate("DELETE FROM " + prefix + "daily_missions");
                 }

--- a/src/main/java/com/Lino/battlePass/placeholders/BattlePassExpansion.java
+++ b/src/main/java/com/Lino/battlePass/placeholders/BattlePassExpansion.java
@@ -160,15 +160,10 @@ public class BattlePassExpansion extends PlaceholderExpansion {
     }
 
     private String getPlayerRank(UUID uuid) {
-        CompletableFuture<List<PlayerData>> future = plugin.getDatabaseManager().getTop10Players();
-        List<PlayerData> topPlayers = future.join();
-
-        for (int i = 0; i < topPlayers.size(); i++) {
-            if (topPlayers.get(i).uuid.equals(uuid)) {
-                return String.valueOf(i + 1);
-            }
+        int[] rankInfo = plugin.getDatabaseManager().getPlayerRankInfo(uuid).join();
+        if (rankInfo[0] > 0) {
+            return String.valueOf(rankInfo[0]);
         }
-
         return "Unranked";
     }
 
@@ -207,7 +202,8 @@ public class BattlePassExpansion extends PlaceholderExpansion {
             String[] parts = identifier.split("_");
             int position = Integer.parseInt(parts[0]);
 
-            if (position < 1 || position > 10) {
+            int maxPosition = plugin.getConfigManager().getLeaderboardSize();
+            if (position < 1 || position > maxPosition) {
                 return "";
             }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -57,6 +57,20 @@ battle-coins:
     9: 2
     10: 1
 
+# Leaderboard configuration
+leaderboard:
+  # Sort criteria for the top leaderboard
+  # Options: level (current season level), total_levels (cumulative all-time), xp, battle_coins
+  sort-by: level
+  # Secondary sort when primary values are tied
+  tiebreaker: xp
+  # Minimum level to appear in the leaderboard (filters inactive players)
+  min-level: 2
+  # How many players to show in the leaderboard GUI (max 27)
+  size: 20
+  # Whether to reset total_levels when a new season starts
+  reset-total-levels-on-season-end: true
+
 # Shop configuration
 shop:
   enabled: true


### PR DESCRIPTION
## Resumen

El leaderboard actualmente ordena por `total_levels`, un contador acumulativo que **nunca se resetea** al cambiar de temporada. Esto hace que los jugadores veteranos ocupen permanentemente las primeras posiciones sin importar su actividad en la temporada actual, anulando el propósito de los resets de temporada.

Este PR agrega configurabilidad completa al leaderboard y corrige el comportamiento del reset de temporada.

### Cambios

**Ordenamiento configurable del leaderboard** (`config.yml`):
```yaml
leaderboard:
  sort-by: level          # Opciones: level, total_levels, xp, battle_coins
  tiebreaker: xp          # Ordenamiento secundario para desempates
  min-level: 2            # Filtra jugadores inactivos
  size: 20                # Jugadores mostrados (máx 27, antes hardcodeado a 10)
  reset-total-levels-on-season-end: true  # Resetea el contador acumulativo al cambiar temporada
```

**Posición del jugador**: Nuevo item "Tu Posición" (RECOVERY_COMPASS, slot 31) que muestra a cada jugador su posición en el ranking aunque no esté en el top. Usa una query eficiente con `COUNT(*)` en vez de cargar todos los jugadores del top.

**Barra de progreso XP**: Barra visual en el lore de cada jugador mostrando su progreso de XP hacia el siguiente nivel.

**Corrección del reset de temporada**: `resetSeason()` ahora opcionalmente resetea `total_levels` a 0 cuando `reset-total-levels-on-season-end: true`, para que el leaderboard refleje correctamente la actividad de la temporada actual.

### El problema (antes de este PR)

| Posición | Jugador | Nivel Actual | XP Actual | total_levels | Justo? |
|---|---|---|---|---|---|
| #1 | JugadorVeterano | 5 | 29 | 167 | No — apenas jugó esta temporada |
| #3 | JugadorActivo | 54 | 9,388 | 54 | Debería ser #1 |

Con `sort-by: level` y `reset-total-levels-on-season-end: true`, el leaderboard refleja correctamente quién está jugando la temporada actual.

### Retrocompatible

- Los valores por defecto mantienen el comportamiento existente si no se configura
- No requiere cambios en el esquema de la base de datos
- Todos los placeholders existentes siguen funcionando