### PR TITLE
feat: Misiones por temporada con restricciones de mundo y región WorldGuard

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
             <name>Lumine Releases</name>
             <url>https://mvn.lumine.io/repository/maven-public/</url>
         </repository>
+        <repository>
+            <id>enginehub</id>
+            <url>https://maven.enginehub.org/repo/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -88,6 +92,19 @@
             <groupId>io.lumine</groupId>
             <artifactId>Mythic-Dist</artifactId>
             <version>5.6.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.sk89q.worldguard</groupId>
+            <artifactId>worldguard-bukkit</artifactId>
+            <version>7.0.9</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-bukkit</artifactId>
+            <version>7.3.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/com/Lino/battlePass/managers/ConfigManager.java
+++ b/src/main/java/com/Lino/battlePass/managers/ConfigManager.java
@@ -14,6 +14,7 @@ public class ConfigManager {
     private final BattlePass plugin;
     private FileConfiguration config;
     private FileConfiguration missionsConfig;
+    private FileConfiguration seasonMissionsConfig;
     private FileConfiguration messagesConfig;
     private FileConfiguration battlePassFreeConfig;
     private FileConfiguration battlePassPremiumConfig;
@@ -108,6 +109,22 @@ public class ConfigManager {
         missionsConfig = YamlConfiguration.loadConfiguration(missionsFile);
         dailyMissionsCount = missionsConfig.getInt("daily-missions-count", 7);
 
+        seasonMissionsConfig = null;
+        try {
+            SeasonRotationManager rotation = plugin.getSeasonRotationManager();
+            if (rotation != null && rotation.isRotationEnabled()) {
+                File seasonMissions = new File(plugin.getDataFolder(),
+                    "seasons/season-" + rotation.getCurrentSeason() + "/missions.yml");
+                if (seasonMissions.exists()) {
+                    seasonMissionsConfig = YamlConfiguration.loadConfiguration(seasonMissions);
+                    plugin.getLogger().info("Loading season-specific missions from: season-" + rotation.getCurrentSeason());
+                    if (seasonMissionsConfig.isSet("daily-missions-count")) {
+                        dailyMissionsCount = seasonMissionsConfig.getInt("daily-missions-count", dailyMissionsCount);
+                    }
+                }
+            }
+        } catch (Exception ignored) {}
+
         File messagesFile = new File(plugin.getDataFolder(), "messages.yml");
         messagesConfig = YamlConfiguration.loadConfiguration(messagesFile);
 
@@ -143,6 +160,10 @@ public class ConfigManager {
 
     public FileConfiguration getMissionsConfig() {
         return missionsConfig;
+    }
+
+    public FileConfiguration getSeasonMissionsConfig() {
+        return seasonMissionsConfig;
     }
 
     public FileConfiguration getMessagesConfig() {

--- a/src/main/java/com/Lino/battlePass/managers/DatabaseManager.java
+++ b/src/main/java/com/Lino/battlePass/managers/DatabaseManager.java
@@ -175,6 +175,14 @@ public class DatabaseManager {
                         "date TEXT)"
                 );
 
+                // Migration: add world and region columns if they don't exist
+                try {
+                    stmt.executeUpdate("ALTER TABLE " + prefix + "daily_missions ADD COLUMN world TEXT DEFAULT NULL");
+                } catch (SQLException ignored) {}
+                try {
+                    stmt.executeUpdate("ALTER TABLE " + prefix + "daily_missions ADD COLUMN region TEXT DEFAULT NULL");
+                } catch (SQLException ignored) {}
+
                 if (!isMySQL) {
                     stmt.executeUpdate("CREATE INDEX IF NOT EXISTS idx_missions_uuid_date ON " + prefix + "missions(uuid, date)");
                 }
@@ -567,8 +575,8 @@ public class DatabaseManager {
             if (missions.isEmpty()) return;
 
             String insertSql = isMySQL
-                    ? "INSERT INTO " + prefix + "daily_missions (name, type, target, required, xp_reward, date) VALUES (?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name)"
-                    : "INSERT OR REPLACE INTO " + prefix + "daily_missions (name, type, target, required, xp_reward, date) VALUES (?, ?, ?, ?, ?, ?)";
+                    ? "INSERT INTO " + prefix + "daily_missions (name, type, target, required, xp_reward, date, world, region) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON DUPLICATE KEY UPDATE name=VALUES(name)"
+                    : "INSERT OR REPLACE INTO " + prefix + "daily_missions (name, type, target, required, xp_reward, date, world, region) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 
             Connection conn = null;
             boolean shouldClose = isMySQL;
@@ -587,6 +595,8 @@ public class DatabaseManager {
                         ps.setInt(4, mission.required);
                         ps.setInt(5, mission.xpReward);
                         ps.setString(6, missionDate);
+                        ps.setString(7, mission.world);
+                        ps.setString(8, mission.region);
                         ps.addBatch();
                     }
                     ps.executeBatch();
@@ -616,12 +626,20 @@ public class DatabaseManager {
                     ps.setString(1, missionDate);
                     try (ResultSet rs = ps.executeQuery()) {
                         while (rs.next()) {
+                            String world = null;
+                            String region = null;
+                            try {
+                                world = rs.getString("world");
+                                region = rs.getString("region");
+                            } catch (SQLException ignored) {}
                             loadedMissions.add(new Mission(
                                     rs.getString("name"),
                                     rs.getString("type"),
                                     rs.getString("target"),
                                     rs.getInt("required"),
-                                    rs.getInt("xp_reward")
+                                    rs.getInt("xp_reward"),
+                                    world,
+                                    region
                             ));
                         }
                     }

--- a/src/main/java/com/Lino/battlePass/managers/MissionGenerator.java
+++ b/src/main/java/com/Lino/battlePass/managers/MissionGenerator.java
@@ -17,16 +17,47 @@ public class MissionGenerator {
     }
 
     public List<Mission> generateDailyMissions(String missionDate) {
-        ConfigurationSection pools = configManager.getMissionsConfig().getConfigurationSection("mission-pools");
-        if (pools == null) {
-            return new ArrayList<>();
-        }
-
         List<Mission> newMissions = new ArrayList<>();
         List<WeightedMissionTemplate> weightedTemplates = new ArrayList<>();
-        Map<String, MissionTemplate> uniqueTemplates = new HashMap<>();
+
+        // Load global mission pool
+        loadPoolFromConfig(configManager.getMissionsConfig(), weightedTemplates);
+
+        // Merge season-specific mission pool (keys prefixed with "season_" to avoid collisions)
+        FileConfiguration seasonConfig = configManager.getSeasonMissionsConfig();
+        if (seasonConfig != null) {
+            loadPoolFromConfig(seasonConfig, weightedTemplates);
+        }
+
+        if (weightedTemplates.isEmpty()) {
+            return newMissions;
+        }
+
+        int missionsToGenerate = configManager.getDailyMissionsCount();
+
+        for (int i = 0; i < missionsToGenerate && !weightedTemplates.isEmpty(); i++) {
+            WeightedMissionTemplate selected = selectWeightedRandom(weightedTemplates);
+
+            if (selected != null) {
+                Mission mission = createMissionFromTemplate(selected.template);
+                newMissions.add(mission);
+                weightedTemplates.removeIf(w -> w.key.equals(selected.key));
+            }
+        }
+
+        return newMissions;
+    }
+
+    private void loadPoolFromConfig(FileConfiguration config, List<WeightedMissionTemplate> weightedTemplates) {
+        ConfigurationSection pools = config.getConfigurationSection("mission-pools");
+        if (pools == null) return;
+
+        Set<String> existingKeys = new HashSet<>();
+        for (WeightedMissionTemplate w : weightedTemplates) existingKeys.add(w.key);
 
         for (String key : pools.getKeys(false)) {
+            if (existingKeys.contains(key)) continue; // season overrides global if same key
+
             ConfigurationSection missionSection = pools.getConfigurationSection(key);
             if (missionSection == null) continue;
 
@@ -38,30 +69,14 @@ public class MissionGenerator {
             int minXP = missionSection.getInt("min-xp");
             int maxXP = missionSection.getInt("max-xp");
             int weight = missionSection.getInt("weight", 10);
+            String world = missionSection.getString("world", null);
+            String region = missionSection.getString("region", null);
 
             MissionTemplate template = new MissionTemplate(displayName, type, target,
-                    minRequired, maxRequired, minXP, maxXP);
+                    minRequired, maxRequired, minXP, maxXP, world, region);
 
-            uniqueTemplates.put(key, template);
             weightedTemplates.add(new WeightedMissionTemplate(template, weight, key));
         }
-
-        int missionsToGenerate = configManager.getDailyMissionsCount();
-        Set<String> usedMissionKeys = new HashSet<>();
-
-        for (int i = 0; i < missionsToGenerate && !weightedTemplates.isEmpty(); i++) {
-            WeightedMissionTemplate selected = selectWeightedRandom(weightedTemplates);
-
-            if (selected != null) {
-                Mission mission = createMissionFromTemplate(selected.template);
-                newMissions.add(mission);
-                usedMissionKeys.add(selected.key);
-
-                weightedTemplates.removeIf(w -> w.key.equals(selected.key));
-            }
-        }
-
-        return newMissions;
     }
 
     private WeightedMissionTemplate selectWeightedRandom(List<WeightedMissionTemplate> weightedTemplates) {
@@ -96,7 +111,7 @@ public class MissionGenerator {
                 .replace("<amount>", String.valueOf(required))
                 .replace("<target>", formatTarget(template.target));
 
-        return new Mission(name, template.type, template.target, required, xpReward);
+        return new Mission(name, template.type, template.target, required, xpReward, template.world, template.region);
     }
 
     private String formatTarget(String target) {

--- a/src/main/java/com/Lino/battlePass/managers/MissionProgressTracker.java
+++ b/src/main/java/com/Lino/battlePass/managers/MissionProgressTracker.java
@@ -40,6 +40,16 @@ public class MissionProgressTracker {
 
             if (!mission.target.equals("ANY") && !mission.target.equals(target)) continue;
 
+            // World check
+            if (mission.world != null && !mission.world.isEmpty()) {
+                if (!player.getWorld().getName().equalsIgnoreCase(mission.world)) continue;
+            }
+
+            // Region check
+            if (mission.region != null && !mission.region.isEmpty()) {
+                if (!isInWorldGuardRegion(player, mission.region)) continue;
+            }
+
             String missionKey = generateMissionKey(mission);
 
             if (completedKeys.contains(missionKey)) {
@@ -83,6 +93,20 @@ public class MissionProgressTracker {
 
         if (changed) {
             plugin.getPlayerDataManager().markForSave(player.getUniqueId());
+        }
+    }
+
+    private boolean isInWorldGuardRegion(Player player, String regionName) {
+        try {
+            if (Bukkit.getPluginManager().getPlugin("WorldGuard") == null) return false;
+            com.sk89q.worldguard.protection.regions.RegionContainer container =
+                com.sk89q.worldguard.WorldGuard.getInstance().getPlatform().getRegionContainer();
+            com.sk89q.worldguard.protection.regions.RegionQuery query = container.createQuery();
+            com.sk89q.worldguard.protection.ApplicableRegionSet set =
+                query.getApplicableRegions(com.sk89q.worldedit.bukkit.BukkitAdapter.adapt(player.getLocation()));
+            return set.getRegions().stream().anyMatch(r -> r.getId().equalsIgnoreCase(regionName));
+        } catch (Exception e) {
+            return false;
         }
     }
 

--- a/src/main/java/com/Lino/battlePass/models/Mission.java
+++ b/src/main/java/com/Lino/battlePass/models/Mission.java
@@ -6,12 +6,20 @@ public class Mission {
     public final String target;
     public final int required;
     public final int xpReward;
+    public final String world;   // null = any world
+    public final String region;  // null = any region
 
     public Mission(String name, String type, String target, int required, int xpReward) {
+        this(name, type, target, required, xpReward, null, null);
+    }
+
+    public Mission(String name, String type, String target, int required, int xpReward, String world, String region) {
         this.name = name;
         this.type = type;
         this.target = target;
         this.required = required;
         this.xpReward = xpReward;
+        this.world = world;
+        this.region = region;
     }
 }

--- a/src/main/java/com/Lino/battlePass/models/MissionTemplate.java
+++ b/src/main/java/com/Lino/battlePass/models/MissionTemplate.java
@@ -8,9 +8,16 @@ public class MissionTemplate {
     public final int maxRequired;
     public final int minXP;
     public final int maxXP;
+    public final String world;
+    public final String region;
 
     public MissionTemplate(String nameFormat, String type, String target, int minRequired,
                            int maxRequired, int minXP, int maxXP) {
+        this(nameFormat, type, target, minRequired, maxRequired, minXP, maxXP, null, null);
+    }
+
+    public MissionTemplate(String nameFormat, String type, String target, int minRequired,
+                           int maxRequired, int minXP, int maxXP, String world, String region) {
         this.nameFormat = nameFormat;
         this.type = type;
         this.target = target;
@@ -18,5 +25,7 @@ public class MissionTemplate {
         this.maxRequired = maxRequired;
         this.minXP = minXP;
         this.maxXP = maxXP;
+        this.world = world;
+        this.region = region;
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,7 +4,7 @@ main: com.Lino.battlePass.BattlePass
 api-version: '1.21'
 author: Lino
 website: https://www.spigotmc.org/resources/battlepass.125992/
-softdepend: [PlaceholderAPI, MythicMobs]
+softdepend: [PlaceholderAPI, MythicMobs, WorldGuard]
 
 libraries:
   - com.zaxxer:HikariCP:5.1.0


### PR DESCRIPTION
## Resumen

Agrega soporte para **misiones temáticas por temporada** que se fusionan con el pool global de misiones, más restricciones de **mundo** y **región de WorldGuard** para misiones.

### Nuevas funcionalidades

**1. Pool de misiones por temporada**

Colocar un `missions.yml` dentro de cualquier carpeta `seasons/season-N/`. Sus misiones se **fusionan** con el pool global de `missions.yml` — no lo reemplazan. Si una misión de temporada usa la misma key que una global, la reemplaza (útil para dar más XP a misiones relevantes de la temporada).

```
plugins/BattlePass/
├── missions.yml                          ← Pool global (siempre activo)
└── seasons/
    └── season-2/
        ├── BattlePassFREE.yml
        ├── BattlePassPREMIUM.yml
        └── missions.yml                  ← Pool de temporada (se fusiona con el global)
```

El `missions.yml` de temporada también puede sobreescribir `daily-missions-count` para dar más o menos misiones diarias durante temporadas específicas.

**2. Misiones restringidas por mundo (campo `world:`)**

Nuevo campo opcional. El progreso solo cuenta cuando el jugador está en el mundo especificado:

```yaml
mission-pools:
  nether-kill-blazes:
    type: KILL_MOB
    target: BLAZE
    display-name: "Mata <amount> Blazes en el Nether"
    min-required: 10
    max-required: 25
    min-xp: 400
    max-xp: 600
    weight: 15
    world: world_nether
```

**3. Misiones restringidas por región WorldGuard (campo `region:`)**

Nuevo campo opcional. El progreso solo cuenta cuando el jugador está dentro de una región de WorldGuard:

```yaml
mission-pools:
  pueblo-comercio:
    type: TRADE_VILLAGER
    target: ANY
    display-name: "Comercia <amount> veces en el Pueblo"
    min-required: 10
    max-required: 30
    min-xp: 250
    max-xp: 400
    weight: 12
    region: pueblo_spawn
```

WorldGuard es una **dependencia opcional (soft)** — si no está instalado, las misiones con `region:` simplemente no progresan. Todas las llamadas a la API de WorldGuard usan nombres de clase completos dentro de try-catch para evitar ClassNotFoundException.

### Detalles técnicos

- `Mission.java` / `MissionTemplate.java`: Campos `world` y `region` con constructores retrocompatibles
- `MissionGenerator.java`: Nuevo método `loadPoolFromConfig()` que carga y fusiona múltiples fuentes de config
- `MissionProgressTracker.java`: Verifica nombre del mundo y región de WorldGuard antes de contar progreso
- `ConfigManager.java`: Carga `seasonMissionsConfig` desde la carpeta de temporada si existe (null-safe)
- `DatabaseManager.java`: Auto-migración de tabla `daily_missions` con columnas `world`/`region` via ALTER TABLE
- `pom.xml`: WorldGuard 7.0.9 + WorldEdit 7.3.0 como dependencias provided
- `plugin.yml`: WorldGuard agregado a softdepend

### Retrocompatible

- Todos los campos nuevos son opcionales — los `missions.yml` existentes funcionan sin cambios
- Las misiones de temporada son aditivas — ningún comportamiento existente cambia si no existe `missions.yml` en la carpeta de temporada
- La migración de base de datos es automática y no destructiva
- WorldGuard es completamente opcional — el plugin funciona perfecto sin él